### PR TITLE
Use a half-edge model to represent rooms more generically

### DIFF
--- a/room.js
+++ b/room.js
@@ -1,54 +1,38 @@
 define([],
 function() {
 
-  // Return an object representing the walls of this room.
-  // Its keys are 'north', 'south', 'east', and 'west'.
-  //
-  // Each of these contains an object with the position
-  // (perpendicular to the wall) and length and start coordinate
-  // (parallel) of that wall, plus the direction it runs from: 
-  // 'east' for walls running east-west (keys 'north' and 'south',
-  // and 'north' for ralls running north-south).
-  // Walls also define 'perpendicularAxis' (used for 'position'),
-  // and 'parallelAxis' (used for 'start'); each one is either 'x' or 'y'.
-  //
-  // TODO: it's more general to represent directions as unit vectors rather than names, and avoids all this case-by-case stuff.
+  // Returns an array of coordinates for the corners of the given room
+  // (by ID) in the given map. This should be enough to draw or describe
+  // the walls.
 
-  walls = function(room) {
-    return {
-      north : {
-        parallelAxis: 'x',
-        perpendicularAxis: 'y',
-        position: room.y,
-        start: room.x,
-        length: room.width,
-        runsFrom: 'west'
-      },
-      south : {
-        parallelAxis: 'x',
-        perpendicularAxis: 'y',
-        position: room.y + room.height,
-        start: room.x,
-        length: room.width,
-        runsFrom: 'west'
-      },
-      east : {
-        parallelAxis: 'y',
-        perpendicularAxis: 'x',
-        position: room.x + room.width,
-        start: room.y,
-        length: room.height,
-        runsFrom: 'north'
-      },
-      west : {
-        parallelAxis: 'y',
-        perpendicularAxis: 'x',
-        position: room.x,
-        start: room.y,
-        length: room.height,
-        runsFrom: 'north'
-      }
-    };
+  var walls = function(map, roomId) {
+    var wallData = [],
+        edge;
+
+    map.rooms.rooms[roomId].edgeLoops.forEach(function(firstEdgeId) {
+      var edgeId = firstEdgeId,
+          edge,
+          startPoint,
+          endPoint;
+      do {
+        edge = map.rooms.edges[edgeId];
+        startPoint = map.rooms.points[edge.from];
+        endPoint = map.rooms.points[edge.to];
+
+        wallData = wallData.concat([
+          {
+            id: edgeId,
+            startX: startPoint.x,
+            startY: startPoint.y,
+            endX: endPoint.x,
+            endY: endPoint.y
+          }
+        ]);
+        edgeId = edge.next;
+      } while (firstEdgeId != edgeId);
+    });
+
+    return wallData;
   };
 
   return {

--- a/test/reducer/map.js
+++ b/test/reducer/map.js
@@ -26,28 +26,52 @@ function(QUnit, Redux, Map, Room) {
         });
       });
 
-      assert.strictEqual(map.rooms[0].x, roomData[0].x);
-      assert.strictEqual(map.rooms[0].y, roomData[0].y);
-      assert.strictEqual(map.rooms[0].width, roomData[0].width);
-      assert.strictEqual(map.rooms[0].height, roomData[0].height);
+      // TODO: do we still need to do map.rooms for things like this?
+      assert.deepEqual(map.rooms.points, [
+        { x: -2, y: 0, edge: 0 }, // 0
+        { x: -1, y: 0, edge: 2 }, // 1
+        { x: -1, y: 2, edge: 4 }, // 2
+        { x: -2, y: 2, edge: 6 }, // 3
 
-      assert.strictEqual(map.rooms[1].x, roomData[1].x);
-      assert.strictEqual(map.rooms[1].y, roomData[1].y);
-      assert.strictEqual(map.rooms[1].width, roomData[1].width);
-      assert.strictEqual(map.rooms[1].height, roomData[1].height);
+        { x: 2, y: -2, edge: 8 }, // 4
+        { x: 6, y: -2, edge: 10 }, // 5
+        { x: 6, y: -1, edge: 12 }, // 6
+        { x: 2, y: -1, edge: 14 }  // 7
+      ]);
 
-      assert.notEqual(map.rooms[0].id, map.rooms[1].id);
+      assert.deepEqual(map.rooms.edges, [
+        { from: 0, to: 1, onRight: 0, opposite: 1, next: 2, cw: 7 },  // 0
+        { from: 1, to: 0, onRight: -1, opposite: 0, next: 7, cw: 2 }, // 1
+        { from: 1, to: 2, onRight: 0, opposite: 3, next: 4, cw: 1 },  // 2
+        { from: 2, to: 1, onRight: -1, opposite: 2, next: 1, cw: 4 }, // 3
+        { from: 2, to: 3, onRight: 0, opposite: 5, next: 6, cw: 3 },  // 4
+        { from: 3, to: 2, onRight: -1, opposite: 4, next: 3, cw: 6 }, // 5
+        { from: 3, to: 0, onRight: 0, opposite: 7, next: 0, cw: 5 },  // 6
+        { from: 0, to: 3, onRight: -1, opposite: 6, next: 5, cw: 0 }, // 7
+
+        { from: 4, to: 5, onRight: 1, opposite: 9, next: 10, cw: 15 },   // 8
+        { from: 5, to: 4, onRight: -1, opposite: 8, next: 15, cw: 10 },  // 9
+        { from: 5, to: 6, onRight: 1, opposite: 11, next: 12, cw: 9 },   // 10
+        { from: 6, to: 5, onRight: -1, opposite: 10, next: 9, cw: 12 },  // 11
+        { from: 6, to: 7, onRight: 1, opposite: 13, next: 14, cw: 11 },  // 12
+        { from: 7, to: 6, onRight: -1, opposite: 12, next: 11, cw: 14 }, // 13
+        { from: 7, to: 4, onRight: 1, opposite: 15, next: 8, cw: 13 },   // 14
+        { from: 4, to: 7, onRight: -1, opposite: 14, next: 13, cw: 8 }   // 15
+      ]);
+
+      assert.deepEqual(map.rooms.rooms[0].edgeLoops, [0]);
+      assert.deepEqual(map.rooms.rooms[1].edgeLoops, [8]);
+      assert.deepEqual(map.rooms.nonRoom.edgeLoops [1, 9])
 
       assert.deepEqual(map.doors, []);
     });
 
     test('tracking room keys', function(assert) {
       var roomData = [
-        { key: 'A', x: -2, y:  0, width: 1, height: 2 },
-        { key: 'B', x:  2, y: -2, width: 4, height: 1 }
-      ];
-
-      var map = undefined;
+          { key: 'A', x: -2, y:  0, width: 1, height: 2 },
+          { key: 'B', x:  2, y: -2, width: 4, height: 1 }
+        ],
+        map;
 
       roomData.forEach(function(room) {
         map = Map.reduce(map, {
@@ -56,141 +80,141 @@ function(QUnit, Redux, Map, Room) {
         });
       });
 
-      assert.strictEqual(map.rooms[0].key, roomData[0].key);
-      assert.strictEqual(map.rooms[1].key, roomData[1].key);
+      assert.strictEqual(map.rooms.rooms[0].key, roomData[0].key);
+      assert.strictEqual(map.rooms.rooms[1].key, roomData[1].key);
     });
 
     test('getting wall details', function(assert) {
-      var room = { key: 'A', x: -2, y:  0, width: 1, height: 2 }
-      var walls = Room.walls(room);
+      var map = Map.reduce(undefined, {
+        type: 'map.rooms.add',
+        payload: { key: 'A', x: -2, y:  0, width: 1, height: 2 }
+      })
+      var walls = Room.walls(map, 0);
 
-      assert.strictEqual(walls.north.perpendicularAxis, 'y');
-      assert.strictEqual(walls.north.parallelAxis, 'x');
-      assert.strictEqual(walls.north.position, room.y);
-      assert.strictEqual(walls.north.start, room.x);
-      assert.strictEqual(walls.north.length, room.width);
-      assert.strictEqual(walls.north.runsFrom, 'west');
-
-      assert.strictEqual(walls.south.perpendicularAxis, 'y');
-      assert.strictEqual(walls.south.parallelAxis, 'x');
-      assert.strictEqual(walls.south.position, room.y + room.height);
-      assert.strictEqual(walls.south.start, room.x);
-      assert.strictEqual(walls.south.length, room.width);
-      assert.strictEqual(walls.south.runsFrom, 'west');
-
-      assert.strictEqual(walls.west.perpendicularAxis, 'x');
-      assert.strictEqual(walls.west.parallelAxis, 'y');
-      assert.strictEqual(walls.west.position, room.x);
-      assert.strictEqual(walls.west.start, room.y);
-      assert.strictEqual(walls.west.length, room.height);
-      assert.strictEqual(walls.west.runsFrom, 'north');
-
-      assert.strictEqual(walls.east.perpendicularAxis, 'x');
-      assert.strictEqual(walls.east.parallelAxis, 'y');
-      assert.strictEqual(walls.east.position, room.x + room.width);
-      assert.strictEqual(walls.east.start, room.y);
-      assert.strictEqual(walls.east.length, room.height);
-      assert.strictEqual(walls.east.runsFrom, 'north');
+      assert.deepEqual(walls, [
+        { startX: -2, startY: 0, endX: -1, endY: 0, id: 0 },
+        { startX: -1, startY: 0, endX: -1, endY: 2, id: 2 },
+        { startX: -1, startY: 2, endX: -2, endY: 2, id: 4 },
+        { startX: -2, startY: 2, endX: -2, endY: 0, id: 6 }
+      ]);
     });
 
     QUnit.module('Exits');
     test('south', function(assert) {
+      var map;
+      map = Map.reduce(map, {type: 'map.rooms.add', payload: { id: 0, x: 0, y: 0, width: 2, height: 2 }});
+      map = Map.reduce(map, {type: 'map.rooms.add', payload: { id: 1, x: 0, y: 2, width: 2, height: 2 }});
 
-      var door = { direction: 'south', x: 0, y: 1 };
-      var north = { id: 0, x: 0, y: 0, width: 2, height: 2 };
-      var south = { id: 1, x: 0, y: 2, width: 2, height: 2 };
-      var map = {
-        rooms: [north, south],
-        doors: [door]
-      };
+      // Assumption: walls IDs are assigned clockwise from top left.
+      assert.deepEqual(Room.walls(map, 0)[2], { startX: 2, startY: 2, endX: 0, endY: 2, id: 4 });
+
+      map = Map.reduce(map, {type: 'map.doors.add', payload: { wallId: 4, position: 1 }});
 
       var exits = Map.exits(map);
-      assert.deepEqual(exits[north.id], [{ door: door, room: south }]);
-      assert.deepEqual(exits[south.id], [{ door: door, room: north }]);
+
+      // TODO: give coordinates of the door itself, not the square it's in.
+      assert.deepEqual(exits[0], [{ door: {bearing: 180, x: 1, y: 1}, room: 1 }]);
+      assert.deepEqual(exits[1], [{ door: {bearing: 180, x: 1, y: 1}, room: 0 }]);
     });
     test('north', function(assert) {
 
-      var door = { direction: 'north', x: 1, y: 2 };
-      var north = { id: 0, x: 0, y: 0, width: 2, height: 2 };
-      var south = { id: 1, x: 0, y: 2, width: 2, height: 2 };
-      var map = {
-        rooms: [north, south],
-        doors: [door]
-      };
+      var map = undefined;
+      map = Map.reduce(map, {type: 'map.rooms.add', payload: { id: 0, x: 0, y: 0, width: 2, height: 2 }});
+      map = Map.reduce(map, {type: 'map.rooms.add', payload: { id: 1, x: 0, y: 2, width: 2, height: 2 }});
+
+      // Assumption: walls IDs are assigned clockwise from top left.
+      assert.deepEqual(Room.walls(map, 1)[0], { startX: 0, startY: 2, endX: 2, endY: 2, id: 8 });
+
+      map = Map.reduce(map, {type: 'map.doors.add', payload: { wallId: 8, position: 1 }});
 
       var exits = Map.exits(map);
-      assert.deepEqual(exits[north.id], [{ door: door, room: south }]);
-      assert.deepEqual(exits[south.id], [{ door: door, room: north }]);
+      assert.deepEqual(exits[0], [{ door: {bearing: 0, x: 0, y: 2}, room: 1 }]);
+      assert.deepEqual(exits[1], [{ door: {bearing: 0, x: 0, y: 2}, room: 0 }]);
     });
     test('east', function(assert) {
 
-      var door = { direction: 'east', x: 1, y: 1 };
-      var west = { id: 0, x: 0, y: 0, width: 2, height: 2 };
-      var east = { id: 1, x: 2, y: 0, width: 2, height: 2 };
-      var map = {
-        rooms: [east, west],
-        doors: [door]
-      };
+      var map = undefined;
+      map = Map.reduce(map, {type: 'map.rooms.add', payload: { id: 0, x: 0, y: 0, width: 2, height: 2 }});
+      map = Map.reduce(map, {type: 'map.rooms.add', payload: { id: 1, x: 2, y: 0, width: 2, height: 2 }});
+
+      // Assumption: walls IDs are assigned clockwise from top left.
+      assert.deepEqual(Room.walls(map, 0)[1], { startX: 2, startY: 0, endX: 2, endY: 2, id: 2 });
+
+      map = Map.reduce(map, {type: 'map.doors.add', payload: { wallId: 2, position: 1 }});
 
       var exits = Map.exits(map);
-      assert.deepEqual(exits[east.id], [{ door: door, room: west }]);
-      assert.deepEqual(exits[west.id], [{ door: door, room: east }]);
+      assert.deepEqual(exits[0], [{ door: {bearing: 90, x: 1, y: 1}, room: 1 }]);
+      assert.deepEqual(exits[1], [{ door: {bearing: 90, x: 1, y: 1}, room: 0 }]);
     });
     test('west', function(assert) {
 
-      var door = { direction: 'west', x: 2, y: 1 };
-      var west = { id: 0, x: 0, y: 0, width: 2, height: 2 };
-      var east = { id: 1, x: 2, y: 0, width: 2, height: 2 };
-      var map = {
-        rooms: [east, west],
-        doors: [door]
-      };
+      var map = undefined;
+      map = Map.reduce(map, {type: 'map.rooms.add', payload: { id: 0, x: 0, y: 0, width: 2, height: 2 }});
+      map = Map.reduce(map, {type: 'map.rooms.add', payload: { id: 1, x: 2, y: 0, width: 2, height: 2 }});
+
+      // Assumption: walls IDs are assigned clockwise from top left.
+      assert.deepEqual(Room.walls(map, 1)[3], { startX: 2, startY: 2, endX: 2, endY: 0, id: 14 });
+
+      map = Map.reduce(map, {type: 'map.doors.add', payload: { wallId: 14, position: 1 }});
 
       var exits = Map.exits(map);
-      assert.deepEqual(exits[east.id], [{ door: door, room: west }]);
-      assert.deepEqual(exits[west.id], [{ door: door, room: east }]);
+      assert.deepEqual(exits[0], [{ door: {bearing: 270, x: 2, y: 0}, room: 1 }]);
+      assert.deepEqual(exits[1], [{ door: {bearing: 270, x: 2, y: 0}, room: 0 }]);
     });
 
     test('multiple exits', function(assert) {
       // Rooms arranged in a cross, with various connections (represented by <, >, ^, v):
-      // (O is the origin)
+      // (O is the origin; numbers are room IDs)
       //
       //    +--+
-      //  O |  |
+      //  O |0 |
       //    |  |
       // +--+-^+--+
-      // |  >  <  |
-      // |  <  |  |
+      // |1 >  < 3|
+      // |  < 2|  |
       // +--+^-+-v+
-      // |  |  |  |
+      // |4 |5 |6 |
       // |  |  |  |
       // +--+--+--+
       //
+      var map = undefined;
+      map = Map.reduce(map, {type: 'map.rooms.add', payload: { x: 2, y: 0, width: 2, height: 2 }});
+      var north = 0;
+      map = Map.reduce(map, {type: 'map.rooms.add', payload: { x: 0, y: 2, width: 2, height: 2 }});
+      var west = 1;
+      map = Map.reduce(map, {type: 'map.rooms.add', payload: { x: 2, y: 2, width: 2, height: 2 }});
+      var centre = 2;
+      map = Map.reduce(map, {type: 'map.rooms.add', payload: { x: 4, y: 2, width: 2, height: 2 }});
+      var east = 3;
+      map = Map.reduce(map, {type: 'map.rooms.add', payload: { x: 0, y: 4, width: 2, height: 2 }});
+      var southwest = 4;
+      map = Map.reduce(map, {type: 'map.rooms.add', payload: { x: 2, y: 4, width: 2, height: 2 }});
+      var south = 5;
+      map = Map.reduce(map, {type: 'map.rooms.add', payload: { x: 4, y: 4, width: 2, height: 2 }});
+      var southeast = 6;
+
+
+      map = Map.reduce(map, {type: 'map.doors.add', payload: { wallId: Room.walls(map.rooms[east])[1].id, position: 0 }});
+      map = Map.reduce(map, {type: 'map.doors.add', payload: { wallId: Room.walls(map.rooms[centre])[0].id, position: 1 }});
+      map = Map.reduce(map, {type: 'map.doors.add', payload: { wallId: Room.walls(map.rooms[centre])[3].id, position: 0 }});
+      map = Map.reduce(map, {type: 'map.doors.add', payload: { wallId: Room.walls(map.rooms[west])[3].id, position: 1 }});
+      map = Map.reduce(map, {type: 'map.doors.add', payload: { wallId: Room.walls(map.rooms[west])[2].id, position: 0 }});
+      map = Map.reduce(map, {type: 'map.doors.add', payload: { wallId: Room.walls(map.rooms[south])[0].id, position: 0 }});
+
       // The coordinates of a door are for the square it's in,
       // and the direction specifies
       // which side of that square it appears on.
-      var westToCentre = { direction: 'east', x: 1, y: 2 };
-      var centreToNorth = { direction: 'north', x: 3, y: 2 };
-      var centreToWest = { direction: 'west', x: 2, y: 3 };
-      var eastToCentre = { direction: 'west', x: 4, y: 2 };
-      var eastToSoutheast = { direction: 'south', x: 5, y: 3 };
-      var southToCentre = { direction: 'north', x: 2, y: 4 };
-
-      var north = { id: 0, x:  2, y: 0, width: 2, height: 2 };
-      var west = { id: 1, x:  0, y: 2, width: 2, height: 2 };
-      var centre = { id: 2, x: 2, y: 2, width: 2, height: 2 };
-      var east = { id: 3, x: 4, y: 2, width: 2, height: 2 };
-      var southwest = { id: 4, x: 0, y: 4, width: 2, height: 2 };
-      var south = { id: 5, x: 2, y: 4, width: 2, height: 2 };
-      var southeast = { id: 6, x: 4, y: 4, width: 2, height: 2 };
-      var map = {
-        rooms: [north, south, east, west, centre, southeast, southwest],
-        doors: [westToCentre, centreToNorth, centreToWest, eastToSoutheast, eastToCentre, southToCentre]
-      };
+      // TODO: should be coordinates of the door itself now.
+      var westToCentre = { bearing: 90, x: 1, y: 2 };
+      var centreToNorth = { bearing: 0, x: 3, y: 2 };
+      var centreToWest = { bearing: 270, x: 2, y: 3 };
+      var eastToCentre = { bearing: 270, x: 4, y: 2 };
+      var eastToSoutheast = { bearing: 180, x: 5, y: 3 };
+      var southToCentre = { bearing: 0, x: 2, y: 4 };
 
       var exits = Map.exits(map);
 
-      assert.unorderedEqual(exits[centre.id], [
+      assert.unorderedEqual(exits[centre], [
         { door: centreToNorth, room: north },
         { door: centreToWest, room: west },
         { door: westToCentre, room: west },
@@ -198,25 +222,25 @@ function(QUnit, Redux, Map, Room) {
         { door: southToCentre, room: south },
       ], 'Centre north, south, east, and twice to the west');
 
-      assert.unorderedEqual(exits[east.id], [
+      assert.unorderedEqual(exits[east], [
         { door: eastToCentre, room: centre },
         { door: eastToSoutheast, room: southeast }
       ], 'East connects to centre and southeast');
-      assert.deepEqual(exits[southeast.id], [
+      assert.deepEqual(exits[southeast], [
         { door: eastToSoutheast, room: east }
       ], 'Southeast connects to east only');
 
-      assert.unorderedEqual(exits[west.id], [
+      assert.unorderedEqual(exits[west], [
         { door: westToCentre, room: centre },
         { door: centreToWest, room: centre }
       ], 'West connects to centre, twice');
-      assert.deepEqual(exits[south.id], [
+      assert.deepEqual(exits[south], [
         { door: southToCentre, room: centre }
       ], 'South connects to centre only');
-      assert.deepEqual(exits[north.id], [
+      assert.deepEqual(exits[north], [
         { door: centreToNorth, room: centre }
       ], 'North connects to centre only');
-      assert.deepEqual(exits[southwest.id], [
+      assert.deepEqual(exits[southwest], [
         // Nothing
       ], 'Southwest is not connected to anything');
     });


### PR DESCRIPTION
Currently we represent a room as (x, y, width, height). This works OK for grid-aligned rectangular rooms, which are the focus of the project anyway -- but doors, in particular are a mess of N/S/E/W special cases.
Using proper computational geometry like this should let us handle all door directions with the same code (plus a rotation angle).

It also opens the door to non-rectangular and non-axis-aligned rooms in future. We would still need a UI to create them though...